### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/brancher/variables.py
+++ b/brancher/variables.py
@@ -845,7 +845,7 @@ class ProbabilisticModel(BrancherClass):
         if not posterior_model:
             self.check_posterior_model()
             posterior_model = self.posterior_model
-        if method is "ELBO":
+        if method == "ELBO":
             empirical_samples = self.observed_submodel._get_sample(1, observed=True, differentiable=False) #TODO Important!!: You need to correct for subsampling
             if for_gradient:
                 function = lambda samples: self.get_p_log_probabilities_from_q_samples(q_samples=samples,


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/AI-DI/Brancher on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./brancher/variables.py:848:12: F632 use ==/!= to compare str, bytes, and int literals
        if method is "ELBO":
           ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```